### PR TITLE
Added link to latest stable version of NextCloud (and OwnCloud)

### DIFF
--- a/README
+++ b/README
@@ -10,21 +10,6 @@ in the computer system tray or on your tablet or handheld device.
 
 Nextcloud is an actively maintained fork of ownCloud.
 
-To download the latest source follow these instructions:
-
-$ git clone https://github.com/nextcloud/client_theming.git
-$ cd client_theming
-$ git submodule update --init --recursive
-
-Go for a coffee
-
-$ cd ..
-$ tar cvf client_theming-2.2.4.tar client_theming
-$ gzip -v9f client_theming-2.2.4.tar
-$ rm -rf client_theming
-
-or get it from the link in the info file
-
 This package optionally requires the Sphinx package in order to create
 _owncloud_  man pages.
 

--- a/nextcloud-client.SlackBuild
+++ b/nextcloud-client.SlackBuild
@@ -65,8 +65,13 @@ rm -rf $PKG
 mkdir -p $TMP $PKG $OUTPUT
 cd $TMP
 rm -rf $SRCNAM
-tar xvf $CWD/$SRCNAM-$VERSION.tar.gz
+ttar xvf $CWD/v$VERSION.tar.gz
+mv $SRCNAM-$VERSION $SRCNAM
 cd $SRCNAM
+tar xvf $CWD/v2.3.0.tar.gz
+rmdir client
+mv client-2.3.0 client
+
 chown -R root:root .
 find -L . \
  \( -perm 777 -o -perm 775 -o -perm 750 -o -perm 711 -o -perm 555 \

--- a/nextcloud-client.SlackBuild
+++ b/nextcloud-client.SlackBuild
@@ -65,7 +65,7 @@ rm -rf $PKG
 mkdir -p $TMP $PKG $OUTPUT
 cd $TMP
 rm -rf $SRCNAM
-ttar xvf $CWD/v$VERSION.tar.gz
+tar xvf $CWD/v$VERSION.tar.gz
 mv $SRCNAM-$VERSION $SRCNAM
 cd $SRCNAM
 tar xvf $CWD/v2.3.0.tar.gz

--- a/nextcloud-client.info
+++ b/nextcloud-client.info
@@ -1,8 +1,10 @@
 PRGNAM="nextcloud-client"
 VERSION="2.2.4"
-HOMEPAGE="httpis://nextcloud.com/"
-DOWNLOAD="TBD"
-MD5SUM=""
+HOMEPAGE="https://nextcloud.com/"
+DOWNLOAD="https://github.com/nextcloud/client_theming/archive/v2.2.4.tar.gz \
+         https://github.com/owncloud/client/archive/v2.3.0.tar.gz"
+MD5SUM="6d612c661f90e5ce1e0791520ecd6df3 \
+       4ab8e97d63296d43299c6da376b077f2"
 DOWNLOAD_x86_64=""
 MD5SUM_x86_64=""
 REQUIRES="qtkeychain"


### PR DESCRIPTION
I came across your SlackBuild trying to install NextCloud on my Slackware laptop, and fiddling around I found how to get direct download links so not to depend on manually downloading from git. I modified your files and tested on my machine and works like a charm. I wanted to give back the changes I made to the installation files.